### PR TITLE
Add empty data field on auto-generated beacons

### DIFF
--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -67,10 +67,13 @@ describe 'ActionsManager', ->
         expect(@instance.actions).to.have.length 1
 
       it 'creates an action with category "site"', ->
-        expect(@instance.actions[0]).to.contain {category:@settings.api.site.key}
+        expect(@instance.actions[0]).to.contain {category: @settings.api.site.key}
 
       it 'creates an action with type "sendPageview"', ->
         expect(@instance.actions[0]).to.contain {type: @settings.api.site.send_pageview}
+
+      it 'creates an action with empty data', ->
+        expect(@instance.actions[0]).to.have.property('data').that.eql({})
 
     context "when a settings:setYogurtSession action is passed", ->
       beforeEach ->

--- a/src/actions_manager.coffee
+++ b/src/actions_manager.coffee
@@ -80,7 +80,7 @@ define [
 
             @actions.push action
 
-      @actions.push {category: api.site.key, type: api.site.send_pageview} unless @actions.length
+      @actions.push {category: api.site.key, type: api.site.send_pageview, data: {}} unless @actions.length
 
       return
 


### PR DESCRIPTION
The server expects every beacon to contain a 'data' field.
