### PR TITLE
Allow ActionManager to receive multiple session category actions without throwing

### DIFF
--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -345,6 +345,13 @@ describe 'ActionsManager', ->
             yogurt_session: @yogurt_session
             yogurt_user_id: @yogurt_user_id
 
+        it 'creates only one session', ->
+          @init2 = ->
+            sa(@category, @type, @shop_code, @yogurt_session, @yogurt_user_id)
+            sa(@category, @type, @shop_code, @yogurt_session, @yogurt_user_id)
+            @init()
+            expect(@session_mock).to.be.calledOnce
+
         api_session_promise_tests()
 
       describe 'connect', ->
@@ -358,6 +365,13 @@ describe 'ActionsManager', ->
         it 'creates a session with type and passes shop_code', ->
           expect(@session_mock).to.be.calledWith @type,
             shop_code: @shop_code
+
+        it 'creates only one session', ->
+          @init2 = ->
+            sa(@category, @type, @shop_code, @yogurt_session, @yogurt_user_id)
+            sa(@category, @type, @shop_code, @yogurt_session, @yogurt_user_id)
+            @init()
+          expect(@session_mock).to.be.calledOnce
 
         api_session_promise_tests()
 

--- a/src/actions_manager.coffee
+++ b/src/actions_manager.coffee
@@ -56,8 +56,7 @@ define [
           @_reportAction 'site', 'sendPageView'
 
     _sessionAction: (type, args)->
-      ## TODO Create custom error class
-      throw new Error('Session already initiated') if @session
+      return if @session?
 
       @session = new Session(type, args)
       @session.then @promise.resolve, @promise.reject


### PR DESCRIPTION
Tackles two minor issues of `ActionManager`:

1. Allows `ActionManager` to receive more than one actions of `session` category without throwing. It skips consuming the action if there is a defined `Session`.

> Not part of this PR anymore
2. Currently, `ActionManager` expects the first action to be of a `session` category in order to `create` or `connect` a session and then consume the rest of actions. Otherwise, a `sendPageView` is reported. Because that is not always the case, a fix is provided to force `ActionManager` consume first actions of `session` category.