### PR TITLE
Use Docker for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:0.10
+MAINTAINER Dimitris Zorbas "zorbash@skroutz.gr"
+ENV PATH ./node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN apt-get -qq update
+RUN npm -g install bower
+RUN npm -g install npm@1.4.29
+WORKDIR /analytics.js

--- a/README.md
+++ b/README.md
@@ -10,6 +10,31 @@ Minimal cross-domain user tracking library to measure user interaction across Sk
 
 ## Install Dependencies
 
+### Using Docker
+
+Install [docker](https://docs.docker.com/engine/installation/),
+[docker-compose](https://docs.docker.com/compose/install/).
+
+Prefix any of the available commands with `docker-compose run builder <command>`.
+
+> Any changes made to the code locally will be reflected inside the
+> container.
+
+Examples:
+
+#### Run the tests
+
+```shell
+docker-compose run builder npm test
+```
+#### Start a shell
+
+```shell
+docker-compose run builder bash
+```
+
+### Installing platform dependencies locally
+
 First, install [`Node.js`](http://nodejs.org/) and its package manager, [`npm`](https://github.com/npm/npm) (`npm` comes by default with `node` now).
 
 Configure `npm` and make available locally installed binaries to your `$PATH`. To do so, just append the following line to your `.{bash|zsh}rc`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+builder:
+  build: .
+  volumes:
+    - .:/analytics.js


### PR DESCRIPTION
To be used for development purposes, allowing the platform development dependencies (eg. node, npm) to point to the exact versions used when building the for production.

Any changes made to the code locally will be reflected inside the container.

Usage:

Run the tests
```shell
docker-compose run builder npm test
```

Build
```shell
docker-compose run builder grunt build
```

Watch
```shell
docker-compose run builder grunt watch
```

Start a shell
```shell
docker-compose run builder bash
```