### PR TITLE
Make iframe properly invisible

### DIFF
--- a/src/loader.coffee
+++ b/src/loader.coffee
@@ -14,7 +14,8 @@ library without blocking the `window.onload` event.
   iframe.title = ""
   # iframe.role = "presentation" # a11y
 
-  (iframe.frameElement or iframe).style.cssText = "width: 0; height: 0; border: 0"
+  (iframe.frameElement or iframe).style.cssText =
+    "position: absolute; top: 0; left: 0; width: 1px; height: 1px; opacity: 0; border: none;"
   where = document.getElementsByTagName('script')
   where = where[where.length - 1]
   where.parentNode.insertBefore(iframe, where)


### PR DESCRIPTION
There are cases that iframe breaks the layout of a site.

Use `visibility: hidden;` instead of `display: none;` because Firefox currently does have an issue with `display:none;`
see: [stackoverflow/javascript-problem-with-iframe-thats-hidden-before-loaded/2786429#2786429](http://stackoverflow.com/questions/2730046/javascript-problem-with-iframe-thats-hidden-before-loaded/2786429#2786429)