### PR TITLE
Handle invalid order_id in order_stash plugin

### DIFF
--- a/spec/plugins/order_stash_spec.coffee
+++ b/spec/plugins/order_stash_spec.coffee
@@ -32,10 +32,52 @@ describe 'OrderStash', ->
 
   describe '.constructor', ->
     it 'adds the plugin style to the head', ->
-      expect(window.parent.document.getElementById('sa-order-stash-style')).to.be
+      expect(window.parent.document.getElementById('sa-order-stash-style')).to.exist
 
     it 'adds the plugin markup to the body', ->
-      expect(window.parent.document.getElementById('sa-order-stash-plugin')).to.be
+      expect(window.parent.document.getElementById('sa-order-stash-plugin')).to.exist
+
+    context 'when order_id is "null" string', ->
+      beforeEach (done) ->
+        window.sa_plugins.order_stash.order_id = 'null'
+
+        @subject.parentNode.removeChild(@subject)
+
+        requirejs.undef 'plugins/order_stash'
+        require ['plugins/order_stash'], =>
+          @subject = window.parent.document.getElementById('sa-order-stash-plugin')
+          done()
+
+      it 'does not add the plugin markup to the body', ->
+        expect(window.parent.document.getElementById('sa-order-stash-plugin')).to.not.exist
+
+    context 'when order_id is empty string', ->
+      beforeEach (done) ->
+        window.sa_plugins.order_stash.order_id = ''
+
+        @subject.parentNode.removeChild(@subject)
+
+        requirejs.undef 'plugins/order_stash'
+        require ['plugins/order_stash'], =>
+          @subject = window.parent.document.getElementById('sa-order-stash-plugin')
+          done()
+
+      it 'does not add the plugin markup to the body', ->
+        expect(window.parent.document.getElementById('sa-order-stash-plugin')).to.not.exist
+
+    context 'when order_id is undefined', ->
+      beforeEach (done) ->
+        window.sa_plugins.order_stash.order_id = undefined
+
+        @subject.parentNode.removeChild(@subject)
+
+        requirejs.undef 'plugins/order_stash'
+        require ['plugins/order_stash'], =>
+          @subject = window.parent.document.getElementById('sa-order-stash-plugin')
+          done()
+
+      it 'does not add the plugin markup to the body', ->
+        expect(window.parent.document.getElementById('sa-order-stash-plugin')).to.not.exist
 
   describe 'click dismiss button', ->
     beforeEach -> click_element @subject.querySelectorAll('#sa-order-stash-dismiss')[0]

--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -271,6 +271,9 @@ class OrderStash
   """
 
   constructor: ->
+    order_id = context().order_id
+    return if !order_id? || order_id in ['', 'null']
+
     @addStyle()
     @render()
     @_bindHandlers()


### PR DESCRIPTION
There are cases that a shop reports an order_id that makes no sense.
e.g null as string or empty string

*The purpose of this PR is to disable rendering the plugin if order_id is invalid.*