### PR TITLE
Increase default xdomain_session_timeout to 5s

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -2,7 +2,7 @@ common:
   iframe_message: "get_analytics_session"
   get_param_name: "analytics_session"
   single_beacon: false
-xdomain_session_timeout: 1000
+xdomain_session_timeout: 5000
 auto_pageview_timeout: 1000
 send_auto_pageview: true
 cookies:


### PR DESCRIPTION
There are websites that when trying to extract the analytics session through the XDomainEngine are failing due to the 1sec timeout that is currently the default setting.

An increase to the `xdomain_session_timeout` will not affect the website's performance, nor other analytics actions (pageview etc).