### PR TITLE
Fix for rendering issues in order_stash plugin

### DIFF
--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -46,7 +46,7 @@ class OrderStash
     display: block;
 
     position: fixed;
-    background-color: white;
+    background-color: white !important;
     bottom: 35px;
     padding: 0 0 10px 0;
     width: 250px;
@@ -113,7 +113,7 @@ class OrderStash
     display: inline-block;
     margin: 0;
     padding: 0 20px;
-    color: #333;
+    color: #333 !important;
     font-size: 13px;
     font-family: Verdana, Arial, sans-serif;
   }
@@ -128,7 +128,7 @@ class OrderStash
     height: 36px;
     line-height: 16px;
     background-color: #f68b24 !important;
-    color: white;
+    color: white !important;
     font-family: Verdana, Arial, sans-serif;
     font-weight: bold;
     font-size: 14px;
@@ -186,7 +186,7 @@ class OrderStash
   #sa-order-stash-plugin #sa-order-stash-why {
     display: inline-block;
     margin-top: 17px;
-    color: #909090;
+    color: #909090 !important;
 
     font-size: 12px;
     font-style: italic;
@@ -218,14 +218,14 @@ class OrderStash
     display: inline-block;
     margin: 13px 0 6px 0;
     line-height: 17px;
-    color: #333;
+    color: #333 !important;
     font-family: Verdana, Arial, sans-serif;
     font-size: 13px;
   }
 
   #sa-order-stash-plugin #sa-order-stash-rationale p.sa-order-stash-privacy {
     font-size: 11px;
-    color: #909090;
+    color: #909090 !important;
     margin-bottom: 0;
   }
 

--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -52,7 +52,7 @@ class OrderStash
     width: 250px;
     height: 220px;
     text-align: center;
-    font-family: Verdana, Arial, sans-serif;
+    font-family: Verdana, Arial, sans-serif !important;
     box-shadow: 0px 1px 11px 0px rgba(77,77,77,0.33);
 
     #{switch configuration.position
@@ -114,8 +114,8 @@ class OrderStash
     margin: 0;
     padding: 0 20px;
     color: #333 !important;
-    font-size: 13px;
-    font-family: Verdana, Arial, sans-serif;
+    font-size: 13px !important;
+    font-family: Verdana, Arial, sans-serif !important;
   }
 
   #sa-order-stash-plugin #sa-order-stash-privacy {
@@ -129,9 +129,9 @@ class OrderStash
     line-height: 16px;
     background-color: #f68b24 !important;
     color: white !important;
-    font-family: Verdana, Arial, sans-serif;
+    font-family: Verdana, Arial, sans-serif !important;
     font-weight: bold;
-    font-size: 14px;
+    font-size: 14px !important;
 
     margin-top: 18px;
     padding: 10px 15px;
@@ -168,7 +168,7 @@ class OrderStash
    margin-bottom: 8px;
 
    font-weight: normal;
-   font-size: 12px;
+   font-size: 12px !important;
    background-position: 220px 17px;
 
    transition: none;
@@ -188,7 +188,7 @@ class OrderStash
     margin-top: 17px;
     color: #909090 !important;
 
-    font-size: 12px;
+    font-size: 12px !important;
     font-style: italic;
     line-height: 13px;
     box-sizing: border-box;
@@ -211,7 +211,7 @@ class OrderStash
   }
 
   #sa-order-stash-plugin #sa-order-stash-rationale p:first-child {
-    font-size: 14px;
+    font-size: 14px !important;
   }
 
   #sa-order-stash-plugin #sa-order-stash-rationale p {
@@ -219,12 +219,12 @@ class OrderStash
     margin: 13px 0 6px 0;
     line-height: 17px;
     color: #333 !important;
-    font-family: Verdana, Arial, sans-serif;
-    font-size: 13px;
+    font-family: Verdana, Arial, sans-serif !important;
+    font-size: 13px !important;
   }
 
   #sa-order-stash-plugin #sa-order-stash-rationale p.sa-order-stash-privacy {
-    font-size: 11px;
+    font-size: 11px !important;
     color: #909090 !important;
     margin-bottom: 0;
   }


### PR DESCRIPTION
Several shops use the `!important` declaration in CSS rules related to `color` or `font-size`, which cause rendering issues to the `order_stash` plugin.

This PR provides a fix for some cases, but there's a more general question that needs to be answered here: should we add `!important` declarations to more or even **all** our `color`, `font-size` CSS rules? Moreover, should we go about doing this to *all* our id-targeting CSS rules? 

This seems a bit kludgy but it's an one-off solution; otherwise we will continue to add such declarations every time we find some rendering issue.