### PR TITLE
Pass flavor/application_name on session create

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -33,7 +33,7 @@ api:
 
 url:
   analytics_session:
-    create: "/track/create?yogurt_session=#{yogurt_session}&yogurt_user_id=#{yogurt_user_id}&shop_code=#{shop_code}"
+    create: "/track/create?yogurt_session=#{yogurt_session}&yogurt_user_id=#{yogurt_user_id}&shop_code=#{shop_code}&flavor=#{flavor}"
     connect: "/track/connect?shop_code=#{shop_code}"
   beacon: "/track/actions/create?analytics_session=#{analytics_session}"
   utils:

--- a/spec/session_spec.coffee
+++ b/spec/session_spec.coffee
@@ -188,6 +188,7 @@ describe 'Session', ->
     @yogurt_user_id    = '1234'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
+    @flavor            = 'flavor'
 
     require [
       'promise'
@@ -295,9 +296,10 @@ describe 'Session', ->
           yogurt_user_id: @yogurt_user_id
           yogurt_session: @yogurt_session
           shop_code: @shop_code
+          flavor: @flavor
         @type = @type_create
         @init = =>
-          sa('session', 'create', @shop_code, @yogurt_session, @yogurt_user_id)
+          sa('session', 'create', @shop_code, @yogurt_session, @yogurt_user_id, @flavor)
           @instance = new @session().run()
 
       context 'when first-party cookies are enabled', ->

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -115,11 +115,12 @@ describe 'Settings', ->
         @session = 'foo'
         @yogurt_user_id = '123'
         @shop_code = 'shop_code_1'
+        @flavor = 'skroutz'
 
       describe '.create', ->
         it 'returns the proper create endpoint', ->
-          endpoint = "#{@base}/track/create?yogurt_session=#{@session}&yogurt_user_id=#{@yogurt_user_id}&shop_code=#{@shop_code}"
-          expect(@settings.url.analytics_session.create(@shop_code, @session, @yogurt_user_id))
+          endpoint = "#{@base}/track/create?yogurt_session=#{@session}&yogurt_user_id=#{@yogurt_user_id}&shop_code=#{@shop_code}&flavor=#{@flavor}"
+          expect(@settings.url.analytics_session.create(@shop_code, @session, @yogurt_user_id, @flavor))
             .to.equal(endpoint)
 
       describe '.connect', ->

--- a/spec/xdomain_engine_spec.coffee
+++ b/spec/xdomain_engine_spec.coffee
@@ -20,6 +20,7 @@ describe 'XDomain Session Retrieval Engine', ->
     @yogurt_user_id    = '1234'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
+    @flavor            = 'flavor'
 
     require [
       'settings'
@@ -99,7 +100,7 @@ describe 'XDomain Session Retrieval Engine', ->
 
     context 'when called with type "create"', ->
       beforeEach ->
-        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @yogurt_user_id)
+        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @yogurt_user_id, @flavor)
         return
 
       it 'opens "track/create" url', ->
@@ -115,6 +116,10 @@ describe 'XDomain Session Retrieval Engine', ->
 
       it 'passes shop_code as a param to the socket url', ->
         url = "shop_code=#{@shop_code}"
+        expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
+
+      it 'passes flavor as a param to the socket url', ->
+        url = "flavor=#{@flavor}"
         expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
 
     context 'when called with type "connect"', ->

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -18,12 +18,13 @@ define [
 
     _commands:
       session:
-        create: (shop_code, yogurt_session, yogurt_user_id) ->
+        create: (shop_code, yogurt_session, yogurt_user_id, flavor) ->
           @shop_code = shop_code
           @yogurt_session = yogurt_session
           @yogurt_user_id = yogurt_user_id
+          @flavor = flavor
 
-          @_extractAnalyticsSession('create', shop_code, yogurt_session, yogurt_user_id)
+          @_extractAnalyticsSession('create', shop_code, yogurt_session, yogurt_user_id, flavor)
 
         connect: (shop_code)->
           @shop_code = shop_code
@@ -45,9 +46,9 @@ define [
       data = Biskoto.get(Settings.cookies.analytics.name)
       if data then data.analytics_session else null
 
-    _extractAnalyticsSession: (type, shop_code, yogurt_session, yogurt_user_id) ->
+    _extractAnalyticsSession: (type, shop_code, yogurt_session, yogurt_user_id, flavor) ->
       Promise.any([
-        (new XDomainEngine(type, shop_code, yogurt_session, yogurt_user_id))
+        (new XDomainEngine(type, shop_code, yogurt_session, yogurt_user_id, flavor))
         (new GetParamEngine())
       ]).then(@_onSessionSuccess, @_onSessionError)
 

--- a/src/session_engines/xdomain_engine.coffee
+++ b/src/session_engines/xdomain_engine.coffee
@@ -4,9 +4,9 @@ define [
   'easyxdm'
 ], (Settings, Promise, easyXDM)->
   class XDomainEngine
-    constructor: (type, shop_code = '', yogurt_session = '', yogurt_user_id = '')->
+    constructor: (type, shop_code = '', yogurt_session = '', yogurt_user_id = '', flavor = '')->
       @promise = new Promise()
-      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, yogurt_user_id)
+      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, yogurt_user_id, flavor)
 
       @socket = @_createSocket @url
       @timeout = @_checkForSocketTimeout()

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -56,9 +56,10 @@ define ->
         @param [String] shop_code Analytics code of the tracked shop
         @param [String] yogurt_session Our Session ID
         @param [String] yogurt_user_id Backend ID of the tracked user
+        @param [String] flavor Application name
         @return [String] The formatted URL
         ###
-        create: (shop_code, yogurt_session, yogurt_user_id)->
+        create: (shop_code, yogurt_session, yogurt_user_id, flavor)->
           "@@analytics_base_url@@url.analytics_session.create"
 
         ###


### PR DESCRIPTION
This PR has to do with SkroutzAnalytics Multitenancy.

We need to run one instance of SkroutzAnalytics to serve multiple tenants/applications of Skroutz (skroutz.gr, alve.com, scrooge.co.uk)