### PR TITLE
Set letter-spacing to zero in order_stash_plugin

### DIFF
--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -52,6 +52,7 @@ class OrderStash
     width: 250px;
     height: 220px;
     text-align: center;
+    letter-spacing: 0;
     font-family: Verdana, Arial, sans-serif !important;
     box-shadow: 0px 1px 11px 0px rgba(77,77,77,0.33);
 


### PR DESCRIPTION
Before
<img width="254" alt="screen shot 2016-12-22 at 17 06 07" src="https://cloud.githubusercontent.com/assets/6564737/21429804/0dd100f2-c869-11e6-98bc-1497130de5d4.png">

After
![screen shot 2016-12-22 at 17 07 23](https://cloud.githubusercontent.com/assets/6564737/21429816/2236183e-c869-11e6-9b73-71b534b0bbf8.png)
