### PR TITLE
Attach 'animationend' event instead of 'transitionend' on click save button

### DIFF
--- a/spec/plugins/order_stash_spec.coffee
+++ b/spec/plugins/order_stash_spec.coffee
@@ -82,22 +82,21 @@ describe 'OrderStash', ->
   describe 'click dismiss button', ->
     beforeEach -> click_element @subject.querySelectorAll('#sa-order-stash-dismiss')[0]
 
-    context 'when the browser supports transitions', ->
+    context 'when the browser supports animations', ->
       beforeEach ->
-        @original_transition = @subject.style.transition
-        @subject.style.transition = ""
-        console.log @subject.style.transition
+        @original_animation = @subject.style.animation
+        @subject.style.animation = ""
         click_element @subject.querySelectorAll('#sa-order-stash-dismiss')[0]
 
-      afterEach -> @subject.style.transition = @original_transition
+      afterEach -> @subject.style.animation = @original_animation
 
       it 'adds the sa-order-stash-slide-out class to the plugin element', ->
         expect(@subject.className).to.eql('sa-order-stash-slide-out')
 
-    context 'when the browser does not support transitions', ->
+    context 'when the browser does not support animations', ->
       beforeEach ->
         click_element @subject.querySelectorAll('#sa-order-stash-dismiss')[0]
-        @subject.style.transition = null
+        @subject.style.animation = null
 
       it 'removes the element', ->
         expect(window.parent.document.getElementById('sa-order-stash-plugin')).

--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -353,7 +353,7 @@ class OrderStash
     element.attachEvent "on#{event}", handler              if element.attachEvent
 
   _onClickDismiss: =>
-    return @$el.className = 'sa-order-stash-slide-out' if @_transitionSupport()
+    return @$el.className = 'sa-order-stash-slide-out' if @_animationSupport()
 
     @$el.parentNode.removeChild(@$el)
 
@@ -373,16 +373,16 @@ class OrderStash
       button.className = 'sa-order-stash-read-more')(@$stashButton())
 
   _onClickStash: (e) =>
-    return unless @_transitionSupport()
+    return unless @_animationSupport()
 
     e.preventDefault()
 
     @$stashButton().removeEventListener('click', @_onClickStash, false)
-    @_attachEvent(@$el, 'transitionend', => @$stashButton().click())
+    @_attachEvent(@$el, 'animationend', => @$stashButton().click())
     @$el.className = 'sa-order-stash-slide-out'
 
   _head: -> @parent_doc.head || @parent_doc.getElementsByTagName('head')[0]
-  _transitionSupport: -> @$el.style.transition?
+  _animationSupport: -> @$el.style.animation?
 
   _setParentDoc: -> @parent_doc = window.parent.document
 


### PR DESCRIPTION
There were 2 issues here:

1. 'transitionend' event was firing multiple times, actually for each
property transitioned("padding-right", "background-color", "background-position-x")
2. 'transitionend' event was working by coincidence, we are using CSS
animations to show/hide order_stash widget, but also we are using CSS
transitions on hover for order_stash button, so that was triggering a
transitionend event.