### PR TITLE
Modify the name and expiration of the first party cookie

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -9,8 +9,8 @@ cookies:
   first_party_enabled: true
   version: 1
   analytics:
-    name: "analytics_session"
-    duration: 2592000 # 1 month
+    name: "__sa_session"
+    duration: 1800 # 30 minutes
 
 api:
   settings:

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -86,13 +86,13 @@ describe 'Settings', ->
       expect(@settings)
         .to.have.deep.property('cookies.analytics.name')
         .that.is.a('string')
-        .that.equals('analytics_session')
+        .that.equals('__sa_session')
 
     it 'has proper .analytics.duration', ->
       expect(@settings)
         .to.have.deep.property('cookies.analytics.duration')
         .that.is.an('number')
-        .that.equals( (60 * 60 * 24 * 30) )
+        .that.equals( (60 * 30) )
 
   describe '.url', ->
     it 'has proper .base', ->


### PR DESCRIPTION
The name of the cookie is too generic, increasing the chance of
conflicts with other services.

The first party cookie expiration, under some cases, might get out
of sync with the third party cookies.