### PR TITLE
Append (friendly) iframe to body if possible

### DIFF
--- a/src/loader.coffee
+++ b/src/loader.coffee
@@ -16,9 +16,13 @@ library without blocking the `window.onload` event.
 
   (iframe.frameElement or iframe).style.cssText =
     "position: absolute; top: 0; left: 0; width: 1px; height: 1px; opacity: 0; border: none;"
-  where = document.getElementsByTagName('script')
-  where = where[where.length - 1]
-  where.parentNode.insertBefore(iframe, where)
+
+  if document.body
+    document.body.appendChild(iframe)
+  else
+    where = document.getElementsByTagName('script')
+    where = where[where.length - 1]
+    where.parentNode.insertBefore(iframe, where)
 
   # Section 2
   try


### PR DESCRIPTION
We found a case were a library [FrDH/jQuery.mmenu](https://github.com/FrDH/jQuery.mmenu) wipes the contents of our (friendly) iframe.

This library uses `$.wrapAll`, the problem with `$.wrapAll` is that it completely wipes the contents of any local iframe.

Actually the plugin does something [like](https://github.com/FrDH/jQuery.mmenu/blob/v6.1.8/src/core/offcanvas/jquery.mmenu.offcanvas.ts#L457):

```js
$("body > div").wrapAll( '<div />' ).parent();
```

So we try to append our iframe to body(if it's available) to avoid appending it inside another element and then having it wiped by [FrDH/jQuery.mmenu](https://github.com/FrDH/jQuery.mmenu).