### PR TITLE
Set font-weight to normal in sa-order-stash-plugin

### DIFF
--- a/src/plugins/order_stash.coffee
+++ b/src/plugins/order_stash.coffee
@@ -54,6 +54,7 @@ class OrderStash
     text-align: center;
     letter-spacing: 0;
     font-family: Verdana, Arial, sans-serif !important;
+    font-weight: normal !important;
     box-shadow: 0px 1px 11px 0px rgba(77,77,77,0.33);
 
     #{switch configuration.position


### PR DESCRIPTION
Explicitly set `font-weight` to sa-order-stash-plugin to `normal`, as it could be overridden by the host's style.
![el_deco_css_order_stash](https://user-images.githubusercontent.com/6564737/28519021-b631f600-7072-11e7-9979-b3d68435805d.png) <img width="253" alt="screen shot 2017-07-24 at 13 19 04" src="https://user-images.githubusercontent.com/6564737/28519029-befc18ba-7072-11e7-872b-4c53cfb4fc10.png">
