### PR TITLE
Toggle floating badge visibility onscroll

### DIFF
--- a/spec/plugins/badge_spec.coffee
+++ b/spec/plugins/badge_spec.coffee
@@ -27,7 +27,7 @@ describe 'Badge', ->
       cb() if cb
       done()
 
-  setSaPlugins = (defaults, { shop_code, display, theme, position, rating }) ->
+  setSaPlugins = (defaults, { shop_code, display, theme, position, hide_onscroll, rating }) ->
     window.sa_plugins =
       badge:
         shop_code: shop_code || defaults.shop_code
@@ -35,6 +35,7 @@ describe 'Badge', ->
           display: display || defaults.display
           theme: theme || defaults.theme
           position: position  || defaults.position
+          hide_onscroll: hide_onscroll || defaults.hide_onscroll
         data:
           rating: rating || defaults.rating
 
@@ -61,6 +62,7 @@ describe 'Badge', ->
       rating: 0.0
       base: 'http://localhost:9000'
       application_base: 'http://test.skroutz.gr'
+      hide_onscroll: false
 
   after -> window.parent.document.addEventListener = orginalAddEventListener
 
@@ -217,6 +219,127 @@ describe 'Badge', ->
 
         it 'shows full stars equal to the integer part, followed by a half star, followed by empty stars up to a maximum of 5 stars', ->
           expect(@subject).to.eql(full_stars: 3, half_stars: 1, empty_stars: 1)
+
+    describe 'show/hide onscroll', ->
+      beforeEach ->
+        @original_body_height = window.parent.document.body.style.height
+        @original_body_width = window.parent.document.body.style.width
+        window.parent.document.body.style.height = '10000px'
+        window.parent.document.body.style.width = '10000px'
+
+      afterEach ->
+        window.parent.document.body.style.height = @original_body_height
+        window.parent.document.body.style.width = @original_body_width
+
+      context 'when hide_onscroll set to true', ->
+        beforeEach -> setSaPlugins(@default_settings, hide_onscroll: true)
+
+        context 'on small screen', ->
+          beforeEach (done) ->
+            @original_viewport_width = window.parent.innerWidth
+            window.parent.innerWidth = 768
+
+            renderPlugin done, =>
+              @subject = window.parent.document.getElementById('sa-badge-floating-plugin')
+
+          afterEach ->
+            window.parent.document.onscroll = null
+            window.parent.innerWidth = @original_viewport_width
+
+          it 'hides floating badge on scroll down', (done) ->
+            window.parent.document.onscroll = =>
+              expect(@subject.style.display).to.eq('none')
+
+              done()
+
+            window.parent.scrollBy(0, 100)
+
+          it 'shows floating badge on scroll up', (done) ->
+            scroll_count = 0
+
+            window.parent.document.onscroll = =>
+              if scroll_count == 1
+                expect(@subject.style.display).to.eq('block')
+
+                done()
+              else
+                scroll_count += 1
+
+                window.parent.scroll(0, 0)
+
+            window.parent.scrollBy(0, 100)
+
+          context 'when scoll horizontally', ->
+            it 'does not change badge visibility', (done) ->
+              window.parent.document.onscroll = =>
+                expect(@subject.style.display).to.eq('')
+
+                done()
+
+              window.parent.scrollBy(100, 0)
+
+        context 'on big screen', ->
+          beforeEach (done) ->
+            @original_viewport_width = window.parent.innerWidth
+            window.parent.innerWidth = 769
+
+            renderPlugin done, =>
+              @subject = window.parent.document.getElementById('sa-badge-floating-plugin')
+
+          afterEach ->
+            window.parent.document.onscroll = null
+            window.parent.innerWidth = @original_viewport_width
+
+          it 'does not change badge visibility', (done) ->
+            window.parent.document.onscroll = =>
+              expect(@subject.style.display).to.eq('')
+
+              done()
+
+            window.parent.scrollBy(0, 100)
+
+      context 'when hide_onscroll set to false', ->
+        beforeEach -> setSaPlugins(@default_settings, hide_onscroll: false)
+
+        context 'on small screen', ->
+          beforeEach (done) ->
+            @original_viewport_width = window.parent.innerWidth
+            window.parent.innerWidth = 768
+
+            renderPlugin done, =>
+              @subject = window.parent.document.getElementById('sa-badge-floating-plugin')
+
+          afterEach ->
+            window.parent.document.onscroll = null
+            window.parent.innerWidth = @original_viewport_width
+
+          it 'does not change badge visibility', (done) ->
+            window.parent.document.onscroll = =>
+              expect(@subject.style.display).to.eq('')
+
+              done()
+
+            window.parent.scrollBy(0, 100)
+
+        context 'on big screen', ->
+          beforeEach (done) ->
+            @original_viewport_width = window.parent.innerWidth
+            window.parent.innerWidth = 769
+
+            renderPlugin done, =>
+              @subject = window.parent.document.getElementById('sa-badge-floating-plugin')
+
+          afterEach ->
+            window.parent.document.onscroll = null
+            window.parent.innerWidth = @original_viewport_width
+
+          it 'does not change badge visibility', (done) ->
+            window.parent.document.onscroll = =>
+              expect(@subject.style.display).to.eq('')
+
+              done()
+
+            window.parent.scrollBy(0, 100)
 
   describe 'embedded', ->
     beforeEach (done) ->

--- a/spec/plugins/badge_spec.coffee
+++ b/spec/plugins/badge_spec.coffee
@@ -110,6 +110,7 @@ describe 'Badge', ->
           .to.eq(["#{@default_settings.application_base}",
                   "/badge/shop_reviews?shop_code=#{@default_settings.shop_code}",
                   "&badge_display=#{@default_settings.display}",
+                  "&hide_onscroll=#{@default_settings.hide_onscroll}"
                   "&origin=#{encodeURIComponent(window.location.origin)}",
                   "&pathname=#{encodeURIComponent(window.location.pathname)}"].join(''))
 
@@ -401,6 +402,7 @@ describe 'Badge', ->
           .to.eq(["#{@default_settings.application_base}",
                   "/badge/shop_reviews?shop_code=#{@default_settings.shop_code}",
                   "&badge_display=#{@default_settings.display}",
+                  "&hide_onscroll=#{@default_settings.hide_onscroll}"
                   "&origin=#{encodeURIComponent(window.location.origin)}",
                   "&pathname=#{encodeURIComponent(window.location.pathname)}"].join(''))
 

--- a/spec/plugins/badge_spec.coffee
+++ b/spec/plugins/badge_spec.coffee
@@ -249,7 +249,8 @@ describe 'Badge', ->
 
           it 'hides floating badge on scroll down', (done) ->
             window.parent.document.onscroll = =>
-              expect(@subject.style.display).to.eq('none')
+              expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(true)
+              expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(false)
 
               done()
 
@@ -260,7 +261,8 @@ describe 'Badge', ->
 
             window.parent.document.onscroll = =>
               if scroll_count == 1
-                expect(@subject.style.display).to.eq('block')
+                expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(false)
+                expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(true)
 
                 done()
               else
@@ -273,7 +275,8 @@ describe 'Badge', ->
           context 'when scoll horizontally', ->
             it 'does not change badge visibility', (done) ->
               window.parent.document.onscroll = =>
-                expect(@subject.style.display).to.eq('')
+                expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(false)
+                expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(true)
 
                 done()
 
@@ -293,7 +296,8 @@ describe 'Badge', ->
 
           it 'does not change badge visibility', (done) ->
             window.parent.document.onscroll = =>
-              expect(@subject.style.display).to.eq('')
+              expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(false)
+              expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(true)
 
               done()
 
@@ -316,7 +320,8 @@ describe 'Badge', ->
 
           it 'does not change badge visibility', (done) ->
             window.parent.document.onscroll = =>
-              expect(@subject.style.display).to.eq('')
+              expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(false)
+              expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(true)
 
               done()
 
@@ -336,7 +341,8 @@ describe 'Badge', ->
 
           it 'does not change badge visibility', (done) ->
             window.parent.document.onscroll = =>
-              expect(@subject.style.display).to.eq('')
+              expect(@subject.classList.contains('sa-badge-floating-hidden')).to.eq(false)
+              expect(@subject.classList.contains('sa-badge-floating-visible')).to.eq(true)
 
               done()
 

--- a/src/plugins/badge.coffee
+++ b/src/plugins/badge.coffee
@@ -11,8 +11,13 @@ class Badge
 
   STYLE = (configuration) -> """
   @keyframes sa-badge-fade-in {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    from { opacity: 0; visibility: hidden; }
+    to   { opacity: 1; visibility: visible; }
+  }
+
+  @keyframes sa-badge-fade-out {
+    from { opacity: 1; visibility: visible; }
+    to   { opacity: 0; visibility: hidden; }
   }
 
   @keyframes sa-badge-spin {
@@ -53,10 +58,25 @@ class Badge
 
     z-index: 2147483647;
 
-    -webkit-animation: sa-badge-fade-in 0.3s ease-in;
-    animation: sa-badge-fade-in 0.3s ease-in;
-
     box-shadow: 0 0 4px rgba(0,0,0,.14), 0 4px 8px rgba(0,0,0,.28);
+  }
+
+  #sa-badge-floating-plugin.sa-badge-floating-visible {
+    visibility: visible;
+
+    -webkit-animation: sa-badge-fade-in 0.3s ease-in;
+            animation: sa-badge-fade-in 0.3s ease-in;
+
+    opacity: 1;
+  }
+
+  #sa-badge-floating-plugin.sa-badge-floating-hidden {
+    visibility: hidden;
+
+    -webkit-animation: sa-badge-fade-out 0.3s ease-out;
+            animation: sa-badge-fade-out 0.3s ease-out;
+
+    opacity: 0;
   }
 
   #sa-badge-floating-plugin.sa-badge-no-stars {
@@ -514,7 +534,8 @@ class Badge
   _renderFloating: ->
     $el = document.createElement('div')
     $el.id = 'sa-badge-floating-plugin'
-    $el.className += 'sa-badge-no-stars' if @_noStars(context().data.rating)
+    $el.className += 'sa-badge-floating-visible'
+    $el.className += ' sa-badge-no-stars' if @_noStars(context().data.rating)
     $el.innerHTML = FLOATING_TEMPLATE(stars: @_ratingToStars(context().data.rating))
     @parent_doc.body.appendChild($el)
 
@@ -624,7 +645,12 @@ class Badge
       scroll_diff = current_scroll - past_scroll
       return if Math.abs(scroll_diff) <= 5
 
-      badge.style.display = if scroll_diff > 0 then 'none' else 'block'
+      if scroll_diff > 0 # scroll down
+        badge.classList.remove('sa-badge-floating-visible')
+        badge.classList.add('sa-badge-floating-hidden')
+      else # scroll up
+        badge.classList.add('sa-badge-floating-visible')
+        badge.classList.remove('sa-badge-floating-hidden')
 
       past_scroll = current_scroll
 

--- a/src/plugins/badge.coffee
+++ b/src/plugins/badge.coffee
@@ -603,6 +603,7 @@ class Badge
     params =
       shop_code: context().shop_code
       badge_display: context().configuration.display
+      hide_onscroll: context().configuration.hide_onscroll
       origin: window.location.origin
       pathname: window.location.pathname
 


### PR DESCRIPTION
Specs:

```
Badge
  floating
    show/hide onscroll
      when hide_on_scroll set to true
        on small screen
          ✔ hides floating badge on scroll down
          ✔ shows floating badge on scroll up
          when scoll horizontally
            ✔ does not change badge visibility
        on big screen
          ✔ does not change badge visibility
      when hide_on_scroll set to false
        on small screen
          ✔ does not change badge visibility
        on big screen
          ✔ does not change badge visibility
```