### PR TITLE
Append referrer url when parsing actions

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -44,5 +44,6 @@ params:
   analytics_session: "analytics_session"
   signature: 'sig'
   url: 'url'
+  referrer: 'referer' # Misspelling of referrer, check https://en.wikipedia.org/wiki/HTTP_referer
   shop_code: 'shop_code'
   actions: 'actions'

--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -36,12 +36,16 @@ action_reporting_tests = ->
       @run()
       @payload = @sendbeacon_spy.args[0][1]
 
-    it 'has url, shop_code and actions keys', ->
+    it 'has url, shop_code, referrer and actions keys', ->
       p = @settings.params
-      expect(@payload).to.have.keys p.url, p.shop_code, p.actions
+      expect(@payload).to.have.keys p.url, p.referrer,
+                                    p.shop_code, p.actions
 
     it 'proper data in url key', ->
       expect(@payload.url).to.equal @settings.url.current
+
+    it 'proper data in referrer key', ->
+      expect(@payload.referer).to.equal @settings.url.referrer
 
     it 'proper data in shop_code key', ->
       expect(@payload.shop_code).to.equal @shop_code

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -75,6 +75,12 @@ describe 'Settings', ->
         .that.is.a('string')
         .that.equals('url')
 
+    it 'has property .referrer', ->
+      expect(@settings.params)
+        .to.have.property('referrer')
+        .that.is.a('string')
+        .that.equals('referer')
+
     it 'has property .shop_code', ->
       expect(@settings.params)
         .to.have.property('shop_code')

--- a/src/actions_manager.coffee
+++ b/src/actions_manager.coffee
@@ -52,6 +52,7 @@ define [
       payload = {}
       params = Settings.params
       payload[params.url] = Settings.url.current
+      payload[params.referrer] = Settings.url.referrer
       payload[params.shop_code] = @session.shop_code
       payload[params.actions] = [{
         category: category

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -31,6 +31,7 @@ define ->
       analytics_session: '@@params.analytics_session'
       signature: '@@params.signature'
       url: '@@params.url'
+      referrer: '@@params.referrer'
       shop_code: '@@params.shop_code'
       actions: '@@params.actions'
 
@@ -120,5 +121,8 @@ define ->
 
   # The current page URL
   Settings.url.current   = Settings.window.location.href
+
+  # The URL of the previous webpage from which a link was followed
+  Settings.url.referrer = Settings.window.document.referrer
 
   return Settings


### PR DESCRIPTION
We use referer (misspelling of referrer) as param key for
compatibility with our backend.

Check: https://en.wikipedia.org/wiki/HTTP_referer