### PR TITLE
Pass metadata on session create

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -33,7 +33,7 @@ api:
 
 url:
   analytics_session:
-    create: "/track/create?yogurt_session=#{yogurt_session}&yogurt_user_id=#{yogurt_user_id}&shop_code=#{shop_code}&flavor=#{flavor}"
+    create: "/track/create?yogurt_session=#{yogurt_session}&yogurt_user_id=#{yogurt_user_id}&shop_code=#{shop_code}&flavor=#{flavor}&metadata=#{metadata}"
     connect: "/track/connect?shop_code=#{shop_code}"
   beacon: "/track/actions/create?analytics_session=#{analytics_session}"
   utils:

--- a/spec/session_spec.coffee
+++ b/spec/session_spec.coffee
@@ -189,6 +189,7 @@ describe 'Session', ->
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
+    @metadata          = JSON.stringify({ app_type: 'web', tags: 'tag1,tag2' })
 
     require [
       'promise'
@@ -302,9 +303,10 @@ describe 'Session', ->
           yogurt_session: @yogurt_session
           shop_code: @shop_code
           flavor: @flavor
+          metadata: @metadata
         @type = @type_create
         @init = =>
-          sa('session', 'create', @shop_code, @yogurt_session, @yogurt_user_id, @flavor)
+          sa('session', 'create', @shop_code, @yogurt_session, @yogurt_user_id, @flavor, @metadata)
           @instance = new @session(@plugins_manager).run()
 
       context 'when first-party cookies are enabled', ->

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -121,11 +121,18 @@ describe 'Settings', ->
         @yogurt_user_id = '123'
         @shop_code = 'shop_code_1'
         @flavor = 'skroutz'
+        @metadata = JSON.stringify({ app_type: 'web', tags: 'tag1,tag2' })
 
       describe '.create', ->
         it 'returns the proper create endpoint', ->
-          endpoint = "#{@base}/track/create?yogurt_session=#{@session}&yogurt_user_id=#{@yogurt_user_id}&shop_code=#{@shop_code}&flavor=#{@flavor}"
-          expect(@settings.url.analytics_session.create(@shop_code, @session, @yogurt_user_id, @flavor))
+          endpoint = "#{@base}/track/create" +
+                     "?yogurt_session=#{@session}" +
+                     "&yogurt_user_id=#{@yogurt_user_id}" +
+                     "&shop_code=#{@shop_code}" +
+                     "&flavor=#{@flavor}" +
+                     "&metadata=#{@metadata}"
+
+          expect(@settings.url.analytics_session.create(@shop_code, @session, @yogurt_user_id, @flavor, @metadata))
             .to.equal(endpoint)
 
       describe '.connect', ->

--- a/spec/xdomain_engine_spec.coffee
+++ b/spec/xdomain_engine_spec.coffee
@@ -21,6 +21,7 @@ describe 'XDomain Session Retrieval Engine', ->
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
+    @metadata          = JSON.stringify({ app_type: 'web', tags: 'tag1,tag2' })
 
     require [
       'settings'
@@ -100,7 +101,7 @@ describe 'XDomain Session Retrieval Engine', ->
 
     context 'when called with type "create"', ->
       beforeEach ->
-        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @yogurt_user_id, @flavor)
+        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @yogurt_user_id, @flavor, @metadata)
         return
 
       it 'opens "track/create" url', ->
@@ -120,6 +121,10 @@ describe 'XDomain Session Retrieval Engine', ->
 
       it 'passes flavor as a param to the socket url', ->
         url = "flavor=#{@flavor}"
+        expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
+
+      it 'passes metadata as a param to the socket url', ->
+        url = "metadata=#{@metadata}"
         expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
 
     context 'when called with type "connect"', ->

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -18,13 +18,13 @@ define [
 
     _commands:
       session:
-        create: (shop_code, yogurt_session, yogurt_user_id, flavor) ->
+        create: (shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
           @shop_code = shop_code
           @yogurt_session = yogurt_session
           @yogurt_user_id = yogurt_user_id
           @flavor = flavor
 
-          @_extractAnalyticsSession('create', shop_code, yogurt_session, yogurt_user_id, flavor)
+          @_extractAnalyticsSession('create', shop_code, yogurt_session, yogurt_user_id, flavor, metadata)
 
         connect: (shop_code)->
           # connect should be called only once
@@ -52,9 +52,9 @@ define [
       data = Biskoto.get(Settings.cookies.analytics.name)
       if data then data.analytics_session else null
 
-    _extractAnalyticsSession: (type, shop_code, yogurt_session, yogurt_user_id, flavor) ->
+    _extractAnalyticsSession: (type, shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
       Promise.any([
-        (new XDomainEngine(type, shop_code, yogurt_session, yogurt_user_id, flavor))
+        (new XDomainEngine(type, shop_code, yogurt_session, yogurt_user_id, flavor, metadata))
         (new GetParamEngine())
       ]).then(@_onSessionSuccess, @_onSessionError)
 

--- a/src/session_engines/xdomain_engine.coffee
+++ b/src/session_engines/xdomain_engine.coffee
@@ -4,9 +4,9 @@ define [
   'easyxdm'
 ], (Settings, Promise, easyXDM)->
   class XDomainEngine
-    constructor: (type, shop_code = '', yogurt_session = '', yogurt_user_id = '', flavor = '')->
+    constructor: (type, shop_code = '', yogurt_session = '', yogurt_user_id = '', flavor = '', metadata = '') ->
       @promise = new Promise()
-      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, yogurt_user_id, flavor)
+      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, yogurt_user_id, flavor, metadata)
 
       @socket = @_createSocket @url
       @timeout = @_checkForSocketTimeout()

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -58,9 +58,10 @@ define ->
         @param [String] yogurt_session Our Session ID
         @param [String] yogurt_user_id Backend ID of the tracked user
         @param [String] flavor Application name
+        @param [String] metadata Additional metadata provided by the base Application
         @return [String] The formatted URL
         ###
-        create: (shop_code, yogurt_session, yogurt_user_id, flavor)->
+        create: (shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
           "@@analytics_base_url@@url.analytics_session.create"
 
         ###


### PR DESCRIPTION
analytics.js will pass additional metadata to the backend on session create via url parameters, provided by the base Application([skroutz](https://skroutz.gr), [alve](https://alve.com), [scrooge](https://scrooge.co.uk)).

The backend will be responsible to set and retrieve these data through 3rd party cookies.

**Note:**
*Additional metadata(as the rest of the params) should be url safe.*
*(This is already being handled by the base application)*