### PR TITLE
Don't send yogurt user id on session creation

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -16,7 +16,6 @@ api:
   settings:
     key: "settings"
     yogurt_session: "setYogurtSession"
-    yogurt_user: "setYogurtUser"
     set_account: "setAccount"
     set_callback: "setCallback"
     redirect_to: "redirectTo"
@@ -33,7 +32,7 @@ api:
 
 url:
   analytics_session:
-    create: "/track/create?yogurt_session=#{yogurt_session}&yogurt_user_id=#{yogurt_user_id}&shop_code=#{shop_code}&flavor=#{flavor}&metadata=#{metadata}"
+    create: "/track/create?yogurt_session=#{yogurt_session}&shop_code=#{shop_code}&flavor=#{flavor}&metadata=#{metadata}"
     connect: "/track/connect?shop_code=#{shop_code}"
   beacon: "/track/actions/create?analytics_session=#{analytics_session}"
   utils:

--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -69,8 +69,6 @@ describe 'ActionsManager', ->
   before (done) ->
     @analytics_session = 'analytics_session'
     @shop_code = 'shop_code'
-    @yogurt_session = 'yogurt_session'
-    @yogurt_user_id = 'yogurt_user_id'
 
     @reset_saq = ->
       @settings.window.sa = =>

--- a/spec/session_spec.coffee
+++ b/spec/session_spec.coffee
@@ -185,7 +185,6 @@ describe 'Session', ->
     @type_create       = 'create'
     @type_connect      = 'connect'
     @yogurt_session    = 'dummy_yogurt_session_hash'
-    @yogurt_user_id    = '1234'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
@@ -299,14 +298,13 @@ describe 'Session', ->
     context 'on session create', ->
       beforeEach ->
         @parsed_settings =
-          yogurt_user_id: @yogurt_user_id
           yogurt_session: @yogurt_session
           shop_code: @shop_code
           flavor: @flavor
           metadata: @metadata
         @type = @type_create
         @init = =>
-          sa('session', 'create', @shop_code, @yogurt_session, @yogurt_user_id, @flavor, @metadata)
+          sa('session', 'create', @shop_code, @yogurt_session, @flavor, @metadata)
           @instance = new @session(@plugins_manager).run()
 
       context 'when first-party cookies are enabled', ->
@@ -324,7 +322,6 @@ describe 'Session', ->
     context 'on session connect', ->
       beforeEach ->
         @parsed_settings =
-          yogurt_user_id: @yogurt_user_id
           yogurt_session: @yogurt_session
           shop_code: @shop_code
         @type = @type_connect

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -118,7 +118,6 @@ describe 'Settings', ->
       beforeEach ->
         @base = @settings.url.base
         @session = 'foo'
-        @yogurt_user_id = '123'
         @shop_code = 'shop_code_1'
         @flavor = 'skroutz'
         @metadata = JSON.stringify({ app_type: 'web', tags: 'tag1,tag2' })
@@ -127,12 +126,11 @@ describe 'Settings', ->
         it 'returns the proper create endpoint', ->
           endpoint = "#{@base}/track/create" +
                      "?yogurt_session=#{@session}" +
-                     "&yogurt_user_id=#{@yogurt_user_id}" +
                      "&shop_code=#{@shop_code}" +
                      "&flavor=#{@flavor}" +
                      "&metadata=#{@metadata}"
 
-          expect(@settings.url.analytics_session.create(@shop_code, @session, @yogurt_user_id, @flavor, @metadata))
+          expect(@settings.url.analytics_session.create(@shop_code, @session, @flavor, @metadata))
             .to.equal(endpoint)
 
       describe '.connect', ->
@@ -183,12 +181,6 @@ describe 'Settings', ->
           .to.have.property('yogurt_session')
           .that.is.a('string')
           .that.equals('setYogurtSession')
-
-      it 'has property .yogurt_user', ->
-        expect(@settings.api.settings)
-          .to.have.property('yogurt_user')
-          .that.is.a('string')
-          .that.equals('setYogurtUser')
 
       it 'has property .set_account', ->
         expect(@settings.api.settings)

--- a/spec/xdomain_engine_spec.coffee
+++ b/spec/xdomain_engine_spec.coffee
@@ -17,7 +17,6 @@ describe 'XDomain Session Retrieval Engine', ->
     define 'easyxdm', [], => @easyxdm_mock
 
     @yogurt_session    = 'dummy_yogurt_session_hash'
-    @yogurt_user_id    = '1234'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
@@ -101,7 +100,7 @@ describe 'XDomain Session Retrieval Engine', ->
 
     context 'when called with type "create"', ->
       beforeEach ->
-        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @yogurt_user_id, @flavor, @metadata)
+        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @flavor, @metadata)
         return
 
       it 'opens "track/create" url', ->
@@ -109,10 +108,6 @@ describe 'XDomain Session Retrieval Engine', ->
 
       it 'passes yogurt_session as a param to the socket url', ->
         url = "yogurt_session=#{@yogurt_session}"
-        expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
-
-      it 'passes yogurt_user_id as a param to the socket url', ->
-        url = "yogurt_user_id=#{@yogurt_user_id}"
         expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
 
       it 'passes shop_code as a param to the socket url', ->

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -20,8 +20,6 @@ define [
       session:
         create: (shop_code, yogurt_session, flavor, metadata) ->
           @shop_code = shop_code
-          @yogurt_session = yogurt_session
-          @flavor = flavor
 
           @_extractAnalyticsSession('create', shop_code, yogurt_session, flavor, metadata)
 

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -18,13 +18,12 @@ define [
 
     _commands:
       session:
-        create: (shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
+        create: (shop_code, yogurt_session, flavor, metadata) ->
           @shop_code = shop_code
           @yogurt_session = yogurt_session
-          @yogurt_user_id = yogurt_user_id
           @flavor = flavor
 
-          @_extractAnalyticsSession('create', shop_code, yogurt_session, yogurt_user_id, flavor, metadata)
+          @_extractAnalyticsSession('create', shop_code, yogurt_session, flavor, metadata)
 
         connect: (shop_code)->
           # connect should be called only once
@@ -52,9 +51,9 @@ define [
       data = Biskoto.get(Settings.cookies.analytics.name)
       if data then data.analytics_session else null
 
-    _extractAnalyticsSession: (type, shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
+    _extractAnalyticsSession: (type, shop_code, yogurt_session, flavor, metadata) ->
       Promise.any([
-        (new XDomainEngine(type, shop_code, yogurt_session, yogurt_user_id, flavor, metadata))
+        (new XDomainEngine(type, shop_code, yogurt_session, flavor, metadata))
         (new GetParamEngine())
       ]).then(@_onSessionSuccess, @_onSessionError)
 

--- a/src/session_engines/xdomain_engine.coffee
+++ b/src/session_engines/xdomain_engine.coffee
@@ -4,9 +4,9 @@ define [
   'easyxdm'
 ], (Settings, Promise, easyXDM)->
   class XDomainEngine
-    constructor: (type, shop_code = '', yogurt_session = '', yogurt_user_id = '', flavor = '', metadata = '') ->
+    constructor: (type, shop_code = '', yogurt_session = '', flavor = '', metadata = '') ->
       @promise = new Promise()
-      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, yogurt_user_id, flavor, metadata)
+      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, flavor, metadata)
 
       @socket = @_createSocket @url
       @timeout = @_checkForSocketTimeout()

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -56,12 +56,11 @@ define ->
         Analytics Tracking Session Creation Endpoint
         @param [String] shop_code Analytics code of the tracked shop
         @param [String] yogurt_session Our Session ID
-        @param [String] yogurt_user_id Backend ID of the tracked user
         @param [String] flavor Application name
         @param [String] metadata Additional metadata provided by the base Application
         @return [String] The formatted URL
         ###
-        create: (shop_code, yogurt_session, yogurt_user_id, flavor, metadata) ->
+        create: (shop_code, yogurt_session, flavor, metadata) ->
           "@@analytics_base_url@@url.analytics_session.create"
 
         ###
@@ -88,7 +87,6 @@ define ->
       settings:
         key: '@@api.settings.key'
         yogurt_session: '@@api.settings.yogurt_session'
-        yogurt_user: '@@api.settings.yogurt_user'
         set_account: '@@api.settings.set_account'
         set_callback: '@@api.settings.set_callback'
         redirect_to: '@@api.settings.redirect_to'


### PR DESCRIPTION
Avoid sending yogurt user id to Skroutz Analytics backend, for GDPR compliance reasons.