### PR TITLE
Don't send yogurt session on session creation

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -15,7 +15,6 @@ cookies:
 api:
   settings:
     key: "settings"
-    yogurt_session: "setYogurtSession"
     set_account: "setAccount"
     set_callback: "setCallback"
     redirect_to: "redirectTo"
@@ -32,7 +31,7 @@ api:
 
 url:
   analytics_session:
-    create: "/track/create?yogurt_session=#{yogurt_session}&shop_code=#{shop_code}&flavor=#{flavor}&metadata=#{metadata}"
+    create: "/track/create?shop_code=#{shop_code}&flavor=#{flavor}&metadata=#{metadata}"
     connect: "/track/connect?shop_code=#{shop_code}"
   beacon: "/track/actions/create?analytics_session=#{analytics_session}"
   utils:

--- a/spec/session_spec.coffee
+++ b/spec/session_spec.coffee
@@ -184,7 +184,6 @@ describe 'Session', ->
   before (done) ->
     @type_create       = 'create'
     @type_connect      = 'connect'
-    @yogurt_session    = 'dummy_yogurt_session_hash'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
@@ -298,13 +297,12 @@ describe 'Session', ->
     context 'on session create', ->
       beforeEach ->
         @parsed_settings =
-          yogurt_session: @yogurt_session
           shop_code: @shop_code
           flavor: @flavor
           metadata: @metadata
         @type = @type_create
         @init = =>
-          sa('session', 'create', @shop_code, @yogurt_session, @flavor, @metadata)
+          sa('session', 'create', @shop_code, @flavor, @metadata)
           @instance = new @session(@plugins_manager).run()
 
       context 'when first-party cookies are enabled', ->
@@ -322,7 +320,6 @@ describe 'Session', ->
     context 'on session connect', ->
       beforeEach ->
         @parsed_settings =
-          yogurt_session: @yogurt_session
           shop_code: @shop_code
         @type = @type_connect
         @init = =>

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -117,7 +117,6 @@ describe 'Settings', ->
     describe '.analytics_session', ->
       beforeEach ->
         @base = @settings.url.base
-        @session = 'foo'
         @shop_code = 'shop_code_1'
         @flavor = 'skroutz'
         @metadata = JSON.stringify({ app_type: 'web', tags: 'tag1,tag2' })
@@ -125,12 +124,11 @@ describe 'Settings', ->
       describe '.create', ->
         it 'returns the proper create endpoint', ->
           endpoint = "#{@base}/track/create" +
-                     "?yogurt_session=#{@session}" +
-                     "&shop_code=#{@shop_code}" +
+                     "?shop_code=#{@shop_code}" +
                      "&flavor=#{@flavor}" +
                      "&metadata=#{@metadata}"
 
-          expect(@settings.url.analytics_session.create(@shop_code, @session, @flavor, @metadata))
+          expect(@settings.url.analytics_session.create(@shop_code, @flavor, @metadata))
             .to.equal(endpoint)
 
       describe '.connect', ->
@@ -175,12 +173,6 @@ describe 'Settings', ->
           .to.have.property('key')
           .that.is.a('string')
           .that.equals('settings')
-
-      it 'has property .yogurt_session', ->
-        expect(@settings.api.settings)
-          .to.have.property('yogurt_session')
-          .that.is.a('string')
-          .that.equals('setYogurtSession')
 
       it 'has property .set_account', ->
         expect(@settings.api.settings)

--- a/spec/xdomain_engine_spec.coffee
+++ b/spec/xdomain_engine_spec.coffee
@@ -16,7 +16,6 @@ describe 'XDomain Session Retrieval Engine', ->
     @easyxdm_socket_spy = sinon.spy(@easyxdm_mock, 'Socket')
     define 'easyxdm', [], => @easyxdm_mock
 
-    @yogurt_session    = 'dummy_yogurt_session_hash'
     @shop_code         = 'shop_code_1'
     @analytics_session = 'dummy_analytics_session_hash'
     @flavor            = 'flavor'
@@ -100,15 +99,11 @@ describe 'XDomain Session Retrieval Engine', ->
 
     context 'when called with type "create"', ->
       beforeEach ->
-        @instance = new @xdomain_engine(@type_create, @shop_code, @yogurt_session, @flavor, @metadata)
+        @instance = new @xdomain_engine(@type_create, @shop_code, @flavor, @metadata)
         return
 
       it 'opens "track/create" url', ->
         expect(@easyxdm_socket_spy.args[0][0].remote).to.contain 'track/create'
-
-      it 'passes yogurt_session as a param to the socket url', ->
-        url = "yogurt_session=#{@yogurt_session}"
-        expect(@easyxdm_socket_spy.args[0][0].remote).to.contain url
 
       it 'passes shop_code as a param to the socket url', ->
         url = "shop_code=#{@shop_code}"

--- a/src/session.coffee
+++ b/src/session.coffee
@@ -18,10 +18,10 @@ define [
 
     _commands:
       session:
-        create: (shop_code, yogurt_session, flavor, metadata) ->
+        create: (shop_code, flavor, metadata) ->
           @shop_code = shop_code
 
-          @_extractAnalyticsSession('create', shop_code, yogurt_session, flavor, metadata)
+          @_extractAnalyticsSession('create', shop_code, flavor, metadata)
 
         connect: (shop_code)->
           # connect should be called only once
@@ -49,9 +49,9 @@ define [
       data = Biskoto.get(Settings.cookies.analytics.name)
       if data then data.analytics_session else null
 
-    _extractAnalyticsSession: (type, shop_code, yogurt_session, flavor, metadata) ->
+    _extractAnalyticsSession: (type, shop_code, flavor, metadata) ->
       Promise.any([
-        (new XDomainEngine(type, shop_code, yogurt_session, flavor, metadata))
+        (new XDomainEngine(type, shop_code, flavor, metadata))
         (new GetParamEngine())
       ]).then(@_onSessionSuccess, @_onSessionError)
 

--- a/src/session_engines/xdomain_engine.coffee
+++ b/src/session_engines/xdomain_engine.coffee
@@ -4,9 +4,9 @@ define [
   'easyxdm'
 ], (Settings, Promise, easyXDM)->
   class XDomainEngine
-    constructor: (type, shop_code = '', yogurt_session = '', flavor = '', metadata = '') ->
+    constructor: (type, shop_code = '', flavor = '', metadata = '') ->
       @promise = new Promise()
-      @url = Settings.url.analytics_session[type](shop_code, yogurt_session, flavor, metadata)
+      @url = Settings.url.analytics_session[type](shop_code, flavor, metadata)
 
       @socket = @_createSocket @url
       @timeout = @_checkForSocketTimeout()

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -55,12 +55,11 @@ define ->
         ###
         Analytics Tracking Session Creation Endpoint
         @param [String] shop_code Analytics code of the tracked shop
-        @param [String] yogurt_session Our Session ID
         @param [String] flavor Application name
         @param [String] metadata Additional metadata provided by the base Application
         @return [String] The formatted URL
         ###
-        create: (shop_code, yogurt_session, flavor, metadata) ->
+        create: (shop_code, flavor, metadata) ->
           "@@analytics_base_url@@url.analytics_session.create"
 
         ###
@@ -86,7 +85,6 @@ define ->
     api:
       settings:
         key: '@@api.settings.key'
-        yogurt_session: '@@api.settings.yogurt_session'
         set_account: '@@api.settings.set_account'
         set_callback: '@@api.settings.set_callback'
         redirect_to: '@@api.settings.redirect_to'


### PR DESCRIPTION
Avoid sending yogurt_session to Skroutz Analytics backend, for GDPR compliance reasons.