### PR TITLE
Set global object to the parent of the current frame when inside a FIF

### DIFF
--- a/tasks/wrappers/analytics/intro.js
+++ b/tasks/wrappers/analytics/intro.js
@@ -1,6 +1,6 @@
 (function(global){
-  // Set global to always reference the outer context's window
+  // Set global to always reference the parent window context
   // Applicable when the script runs inside a FIF
   if(global.inDapIF){
-    global = global.top;
+    global = global.parent;
   }


### PR DESCRIPTION
This fixes a problem with Same-origin security policy when analytics is loaded inside another iframe.

The error:
```
DOMException: Blocked a frame with origin "http://www.<domain>.com" from accessing a cross-origin frame
```

Fixes: #44 