### PR TITLE
Analytics Global Object

### DIFF
--- a/config/settings/development.yml.sample
+++ b/config/settings/development.yml.sample
@@ -1,11 +1,14 @@
 skroutz:
+  analytics_object: "SkroutzAnalyticsObject"
   analytics_base_url: "http://localhost:9000"
   application_base_url: "http://localhost:3000"
 
 alve:
+  analytics_object: "AlveAnalyticsObject"
   analytics_base_url: "http://localhost:9000"
   application_base_url: "http://localhost:3000"
 
 scrooge:
+  analytics_object: "ScroogeAnalyticsObject"
   analytics_base_url: "http://localhost:9000"
   application_base_url: "http://localhost:3000"

--- a/config/settings/testing.yml.sample
+++ b/config/settings/testing.yml.sample
@@ -1,11 +1,14 @@
 skroutz:
+  analytics_object: "SkroutzAnalyticsObject"
   analytics_base_url: "http://localhost:7878"
   application_base_url: "http://localhost:3000"
 
 alve:
+  analytics_object: "AlveAnalyticsObject"
   analytics_base_url: "http://localhost:7878"
   application_base_url: "http://localhost:3000"
 
 scrooge:
+  analytics_object: "ScroogeAnalyticsObject"
   analytics_base_url: "http://localhost:7878"
   application_base_url: "http://localhost:3000"

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -1,8 +1,23 @@
 describe 'Settings', ->
-  before (done) ->
-    require ['settings'], (Settings) =>
-      @settings = Settings
-      done()
+  set_analytics_object = (analytics_object) ->
+    window.SkroutzAnalyticsObject = analytics_object
+
+  unset_analytics_object = -> delete window.SkroutzAnalyticsObject
+
+  beforeEach (done) ->
+    @require_settings = (done) =>
+      requirejs.undef 'settings'
+
+      require ['settings'], (Settings) =>
+        @settings = Settings
+
+        done()
+
+    @require_settings(done)
+
+  afterEach ->
+    unset_analytics_object()
+    delete @settings
 
   describe 'API', ->
     it 'has property .window', ->
@@ -13,6 +28,23 @@ describe 'Settings', ->
       expect(@settings)
         .to.have.property('redirectTo')
         .that.is.an('function')
+
+    describe '.command_queue_name', ->
+      it "defaults to 'sa'", ->
+        expect(@settings)
+          .to.have.property('command_queue_name')
+          .that.equals('sa')
+
+      context 'when Analytics Object is defined', ->
+        beforeEach (done) ->
+          set_analytics_object('skroutz_analytics')
+
+          @require_settings(done)
+
+        it 'assigns the value from Analytics Object', ->
+          expect(@settings)
+            .to.have.property('command_queue_name')
+            .that.equals('skroutz_analytics')
 
     it 'has property .commands_queue', ->
       expect(@settings)

--- a/src/analytics.coffee
+++ b/src/analytics.coffee
@@ -17,8 +17,8 @@ define [
     runs commands. Intended for programmatic usage and/or lazy command declaration.
     ###
     _live: ->
-      Settings.window.sa = =>
-        (Settings.window.sa.q ||= []).push(arguments)
+      Settings.window[Settings.command_queue_name] = =>
+        (Settings.window[Settings.command_queue_name].q ||= []).push(arguments)
         @actions.run()
 
   return Analytics

--- a/src/runnable.coffee
+++ b/src/runnable.coffee
@@ -10,12 +10,12 @@ define ['settings'], (Settings) ->
     then discards it.
     ###
     @run: ->
-      for _, cmd of Settings.window.sa.q.slice()
+      for _, cmd of Settings.window[Settings.command_queue_name].q.slice()
         [category, type, args...] = cmd
 
         if @_commands[category]?[type]?
           @_commands[category][type].apply(@, args)
-          Settings.window.sa.q.splice(Settings.window.sa.q.indexOf(cmd), 1)
+          Settings.window[Settings.command_queue_name].q.splice(Settings.window[Settings.command_queue_name].q.indexOf(cmd), 1)
 
       return @
 

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -109,6 +109,8 @@ define ->
   Define window.sa and window.sa.q
   @todo Needs refactoring and better place to live
   ###
+  Settings.command_queue_name = Settings.window['@@analytics_object'] || 'sa'
+
   Settings.window.sa = Settings.window.sa or ->
     (Settings.window.sa.q = Settings.window.sa.q || []).push(arguments)
     return

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -111,12 +111,15 @@ define ->
   ###
   Settings.command_queue_name = Settings.window['@@analytics_object'] || 'sa'
 
-  Settings.window.sa = Settings.window.sa or ->
-    (Settings.window.sa.q = Settings.window.sa.q || []).push(arguments)
-    return
-  Settings.window.sa.q = Settings.window.sa.q or []
+  Settings.window[Settings.command_queue_name] =
+    Settings.window[Settings.command_queue_name] or ->
+      (Settings.window[Settings.command_queue_name].q = Settings.window[Settings.command_queue_name].q || []).
+        push(arguments)
+      return
 
-  Settings.commands_queue = Settings.window.sa.q
+  Settings.window[Settings.command_queue_name].q = Settings.window[Settings.command_queue_name].q or []
+
+  Settings.commands_queue = Settings.window[Settings.command_queue_name].q
 
   # The current page URL
   Settings.url.current   = Settings.window.location.href

--- a/tasks/wrappers/analytics/outro.js
+++ b/tasks/wrappers/analytics/outro.js
@@ -1,2 +1,2 @@
-  (global.sa = global.sa || {}).analytics = new Analytics();
+  (global[Settings.command_queue_name] = global[Settings.command_queue_name] || {}).analytics = new Analytics();
 })(this)


### PR DESCRIPTION
### Description

Since last week we have a conflict with Google Analytics and our namespace 'sa'.
see: [Google issues#116182847](https://issuetracker.google.com/issues/116182847)

With this change we will support **custom command queue function**(`sa()`) specified by the developer.

------------------------------

We should update also our documentation for Skroutz and Alve.

[Skroutz Analytics Tracking Script](https://developer.skroutz.gr/analytics/#step-1-integrate-the-analytics-tracking-script)

```html
<script type="text/javascript">
  (function(a,b,c,d,e,f,g){a['SkroutzAnalyticsObject']=e;a[e]= a[e] || function(){
    (a[e].q = a[e].q || []).push(arguments);};
    f=b.createElement(c);f.async=true;
    f.src=d;g=b.getElementsByTagName(c)[0];g.parentNode.insertBefore(f,g);
  })(window,document,'script','https://analytics.skroutz.gr/analytics.min.js','skroutz_analytics');

  skroutz_analytics('session', 'connect', 'SA-XXXX-XXXX');  // Connect your Account.
</script>
```

[Alve Analytics Tracking Script](https://developer.alve.com/analytics/#step-1-integrate-the-analytics-tracking-script)

```html
<script type="text/javascript">
  (function(a,b,c,d,e,f,g){a['AlveAnalyticsObject']=e;a[e]= a[e] || function(){
    (a[e].q = a[e].q || []).push(arguments);};
    f=b.createElement(c);f.async=true;
    f.src=d;g=b.getElementsByTagName(c)[0];g.parentNode.insertBefore(f,g);
  })(window,document,'script','https://analytics.alve.com/analytics.min.js','alve_analytics');

  alve_analytics('session', 'connect', 'SA-XXXX-XXXX');  // Connect your Account.
</script>
```
**Note**:  
If you want to add both SkroutzAnalytics and AlveAnalytics, you should use **different** global {Skroutz, Alve} functions.