### PR TITLE
Add presence validations for unique identifiers reported from shops

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -66,10 +66,13 @@ module.exports = (grunt) ->
         options:
           patterns: [json: (done) ->
             settings = grunt.config('env_settings')
-            flavor_settings = settings[grunt.config.get('current_flavor')]
+
+            flavor = grunt.config.get('current_flavor')
+            flavor_settings = settings[flavor]
 
             for property of flavor_settings
               settings[property] = flavor_settings[property]
+            settings.flavor = "#{flavor[0].toUpperCase()}#{flavor.slice(1)}"
 
             done settings
             return

--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -1,3 +1,20 @@
+VALID_ORDER_DATA = {
+  order_id: '123456',
+  revenue:  '1315.25',
+  shipping: '5.45',
+  tax:      '301.25'
+}
+VALID_ORDER_DATA_STRINGIFIED = JSON.stringify(VALID_ORDER_DATA)
+
+VALID_LINE_ITEM_DATA_1 = {
+  order_id:   '123456',
+  product_id: '47299441',
+  name:       'Product 1 Lalastore'
+  price:      '654.90',
+  quantity:   '1'
+}
+VALID_LINE_ITEM_DATA_1_STRINGIFIED = JSON.stringify(VALID_LINE_ITEM_DATA_1)
+
 api_session_promise_tests = ->
   context 'when session retrieval fulfils', ->
     beforeEach ->
@@ -383,6 +400,16 @@ describe 'ActionsManager', ->
             it 'does not execute callback', ->
               expect(@callback_spy).to.not.be.called
 
+        context 'when data are given as unstringified object', ->
+          beforeEach ->
+            @data = VALID_ORDER_DATA
+
+          it 'stringifies the data before reporting', ->
+            @run()
+            payload = @sendbeacon_spy.args[0][1]
+            expect(@sendbeacon_spy).to.be.called
+            expect(payload.actions[0].data).to.eql VALID_ORDER_DATA_STRINGIFIED
+
       describe 'addItem', ->
         beforeEach ->
           @type = 'addItem'
@@ -415,6 +442,16 @@ describe 'ActionsManager', ->
 
             it 'does not execute callback', ->
               expect(@callback_spy).to.not.be.called
+
+        context 'when data are given as unstringified object', ->
+          beforeEach ->
+            @data = VALID_LINE_ITEM_DATA_1
+
+          it 'stringifies the data before reporting', ->
+            @run()
+            payload = @sendbeacon_spy.args[0][1]
+            expect(@sendbeacon_spy).to.be.called
+            expect(payload.actions[0].data).to.eql VALID_LINE_ITEM_DATA_1_STRINGIFIED
 
     describe 'site', ->
       beforeEach ->

--- a/spec/actions_manager_spec.coffee
+++ b/spec/actions_manager_spec.coffee
@@ -15,6 +15,15 @@ VALID_LINE_ITEM_DATA_1 = {
 }
 VALID_LINE_ITEM_DATA_1_STRINGIFIED = JSON.stringify(VALID_LINE_ITEM_DATA_1)
 
+VALID_LINE_ITEM_DATA_2 = {
+  order_id:   '123456',
+  product_id: '987456',
+  name:       'Product 2 Lalastore'
+  price:      '50.90',
+  quantity:   '2'
+}
+VALID_LINE_ITEM_DATA_2_STRINGIFIED = JSON.stringify(VALID_LINE_ITEM_DATA_2)
+
 api_session_promise_tests = ->
   context 'when session retrieval fulfils', ->
     beforeEach ->
@@ -105,6 +114,8 @@ describe 'ActionsManager', ->
       @reporter_spy = sinon.spy @, 'reporter_mock'
       define 'reporter', [], => @reporter_mock
 
+      @console_error_spy = sinon.spy console, 'error'
+
       require [
         'session'
         'plugins_manager'
@@ -129,7 +140,9 @@ describe 'ActionsManager', ->
 
         done()
 
-  after -> window.__requirejs__.clearRequireState()
+  after ->
+    window.__requirejs__.clearRequireState()
+    @console_error_spy.restore()
 
   beforeEach ->
     @old_redirect = @settings.redirectTo
@@ -148,6 +161,7 @@ describe 'ActionsManager', ->
     # Reset mocks
     @sendbeacon_promise = new @promise()
     @sendbeacon_spy.reset()
+    @console_error_spy.reset()
 
   describe '.constructor', ->
     beforeEach ->
@@ -161,9 +175,9 @@ describe 'ActionsManager', ->
 
     context 'when commands exist', ->
       beforeEach ->
-        sa('ecommerce', 'addOrder', 'order_data')
-        sa('ecommerce', 'addItem', 'item_data_1')
-        sa('ecommerce', 'addItem', 'item_data_2')
+        sa('ecommerce', 'addOrder', VALID_ORDER_DATA_STRINGIFIED)
+        sa('ecommerce', 'addItem', VALID_LINE_ITEM_DATA_1_STRINGIFIED)
+        sa('ecommerce', 'addItem', VALID_LINE_ITEM_DATA_2_STRINGIFIED)
 
       it 'consumes all commands already declared', ->
         @subject.run()
@@ -234,7 +248,7 @@ describe 'ActionsManager', ->
       context 'when another action is created', ->
         context 'before timeout expires', ->
           beforeEach ->
-            sa('ecommerce', 'addOrder', 'order_data')
+            sa('ecommerce', 'addOrder', VALID_ORDER_DATA_STRINGIFIED)
             @initializeSubject()
             @subject.run()
 
@@ -248,7 +262,7 @@ describe 'ActionsManager', ->
             expect(@sendbeacon_spy.args[0][1].actions[0]).to.contain
               category: 'ecommerce'
               type: 'addOrder'
-              data: 'order_data'
+              data: VALID_ORDER_DATA_STRINGIFIED
 
           it 'does not send a PageView action', ->
             action_data = @sendbeacon_spy.args[0][1].actions[0]
@@ -260,7 +274,7 @@ describe 'ActionsManager', ->
           beforeEach ->
             @initializeSubject()
             @clock.tick @settings.auto_pageview_timeout + 100
-            sa('ecommerce', 'addOrder', 'order_data')
+            sa('ecommerce', 'addOrder', VALID_ORDER_DATA_STRINGIFIED)
             @subject.run()
 
           it 'clears the AutoPageView timeout', ->
@@ -275,9 +289,9 @@ describe 'ActionsManager', ->
     context 'when API calls are made before library load', ->
       beforeEach ->
         sa('unknown-category', 'unknown-command', 'data')
-        sa('ecommerce', 'addOrder', 'order_data')
-        sa('ecommerce', 'addItem', 'item_data_1')
-        sa('ecommerce', 'addItem', 'item_data_2')
+        sa('ecommerce', 'addOrder', VALID_ORDER_DATA_STRINGIFIED)
+        sa('ecommerce', 'addItem', VALID_LINE_ITEM_DATA_1_STRINGIFIED)
+        sa('ecommerce', 'addItem', VALID_LINE_ITEM_DATA_2_STRINGIFIED)
         @subject.run()
 
       it 'executes every recognized command', ->
@@ -358,7 +372,6 @@ describe 'ActionsManager', ->
     describe 'ecommerce', ->
       beforeEach ->
         @category = 'ecommerce'
-        @data = '{}'
 
         @run = ->
           sa(@category, @type, @data)
@@ -369,6 +382,7 @@ describe 'ActionsManager', ->
       describe 'addOrder', ->
         beforeEach ->
           @type = 'addOrder'
+          @data = VALID_ORDER_DATA_STRINGIFIED
 
         action_reporting_tests()
 
@@ -410,9 +424,53 @@ describe 'ActionsManager', ->
             expect(@sendbeacon_spy).to.be.called
             expect(payload.actions[0].data).to.eql VALID_ORDER_DATA_STRINGIFIED
 
+        describe 'validations', ->
+          context 'when an invalid JSON object is given', ->
+            beforeEach ->
+              @data = "invalid JSON"
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when order_id is missing', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                revenue:  '1315.25',
+                shipping: '5.45',
+                tax:      '301.25'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when order_id is empty', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                order_id: ' \t',
+                revenue:  '1315.25',
+                shipping: '5.45',
+                tax:      '301.25'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
       describe 'addItem', ->
         beforeEach ->
           @type = 'addItem'
+          @data = VALID_LINE_ITEM_DATA_1_STRINGIFIED
 
         action_reporting_tests()
 
@@ -452,6 +510,84 @@ describe 'ActionsManager', ->
             payload = @sendbeacon_spy.args[0][1]
             expect(@sendbeacon_spy).to.be.called
             expect(payload.actions[0].data).to.eql VALID_LINE_ITEM_DATA_1_STRINGIFIED
+
+        describe 'validations', ->
+          context 'when an invalid JSON object is given', ->
+            beforeEach ->
+              @data = "invalid JSON"
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when order_id is missing', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                product_id: '987456',
+                name:       'Product 2 Lalastore'
+                price:      '50.90',
+                quantity:   '2'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when order_id is empty', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                order_id:   ' \t',
+                product_id: '987456',
+                name:       'Product 2 Lalastore'
+                price:      '50.90',
+                quantity:   '2'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when product_id is missing', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                order_id:   '123456',
+                name:       'Product 2 Lalastore'
+                price:      '50.90',
+                quantity:   '2'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
+
+          context 'when product_id is empty', ->
+            beforeEach ->
+              @data = JSON.stringify({
+                order_id:   '123456',
+                product_id: ' \t',
+                name:       'Product 2 Lalastore'
+                price:      '50.90',
+                quantity:   '2'
+              })
+              @run()
+
+            it 'does not report the action', ->
+              expect(@sendbeacon_spy).to.not.be.called
+
+            it 'reports error to console', ->
+              expect(@console_error_spy).to.be.calledOnce
 
     describe 'site', ->
       beforeEach ->

--- a/src/actions_manager.coffee
+++ b/src/actions_manager.coffee
@@ -37,7 +37,7 @@ define [
             ValidationHelper.ensure_key(data, 'order_id', 'addOrder')
             ValidationHelper.ensure_not_empty_string(data, 'order_id', 'addOrder')
           catch e
-            return console?.error? 'Skroutz Analytics | invalid parameters given:', e.message
+            return console?.error? "#{Settings.flavor}Analytics | invalid parameters given:", e.message
 
           @_reportAction 'ecommerce', 'addOrder', data, -> callback() if callback
           @plugins_manager.notify('order', data)
@@ -52,7 +52,7 @@ define [
             ValidationHelper.ensure_key(data, 'product_id', 'addItem')
             ValidationHelper.ensure_not_empty_string(data, 'product_id', 'addItem')
           catch e
-            return console?.error? 'Skroutz Analytics | invalid parameters given:', e.message
+            return console?.error? "#{Settings.flavor}Analytics | invalid parameters given:", e.message
 
           @_reportAction 'ecommerce', 'addItem', data, -> callback() if callback
 

--- a/src/actions_manager.coffee
+++ b/src/actions_manager.coffee
@@ -52,6 +52,8 @@ define [
 
     # TODO: implement multiple actions per beacon maybe??
     _buildBeaconPayload: (category, type, data = '{}') ->
+      if typeof data != 'string'
+        data = JSON.stringify data
       payload = {}
       params = Settings.params
       payload[params.url] = Settings.url.current

--- a/src/helpers/validation_helper.coffee
+++ b/src/helpers/validation_helper.coffee
@@ -1,0 +1,33 @@
+class ValidationError extends Error
+  constructor: (message, reason) ->
+    @message = message
+    @reason = reason
+    @name = "ValidationError"
+
+define ->
+  ValidationHelper =
+    ensure_valid_object: (data, action=null, error_message=null) ->
+      if typeof data == "string"
+        try
+          data = JSON.parse data
+        catch
+          # pass
+      if typeof data == "object"
+        return data
+
+      error_message ||= 'Invalid JSON object'+(if action then " in \"#{action}\" action:\n" else ':\n')+data
+      throw new ValidationError error_message, {failed_test: 'ensure_valid_object', action}
+
+    ensure_key: (data, key, action=null, error_message=null) ->
+      if not data[key]
+        error_message ||= "Missing \"#{key}\""+(if action then " in \"#{action}\" action" else '')
+        throw new ValidationError error_message, {failed_test: 'ensure_key', key, action}
+      data
+
+    ensure_not_empty_string: (data, key, action=null, error_message=null) ->
+      if /^\s*$/.test(data[key])
+        error_message ||= "Empty \"#{key}\""+(if action then " in \"#{action}\" action" else '')
+        throw new ValidationError error_message, {failed_test: 'ensure_not_empty_string', key, action}
+      data
+
+  ValidationHelper

--- a/src/settings.coffee.sample
+++ b/src/settings.coffee.sample
@@ -1,5 +1,7 @@
 define ->
   Settings =
+    flavor: "@@flavor"
+
     ###
     @param [String] url The url to redirect to
     ###


### PR DESCRIPTION
Analytics Tracking Script will:
1. Make sure that the payload given to `addOrder` or `addItem` commands is a valid JSON before reporting them
1. Make sure `addOrder` has been supplied with a non-empty `order_id` field before reporting it
1. Make sure `addItem` has been supplied with non-empty `order_id` and `product_id` fields before reporting it
1. Log appropriate validation errors to console whenever the above constraints are not met

Also, Analytics Tracking Script will:
* Accept (unstringified) Object as payload. `JSON.stringify(...)` is not needed anymore.

------------
Documentation Update: [skroutz/developer.skroutz.gr/pull/93](https://github.com/skroutz/developer.skroutz.gr/pull/93)