### PR TITLE
Extend Duration of Basic Cookies to 30 days

### DIFF
--- a/config/settings/default.yml
+++ b/config/settings/default.yml
@@ -15,7 +15,7 @@ cookies:
       duration: 1800 # 30 minutes
     session:
       name: '__b_skr_nltcs_ss'
-      duration: 60*60*24*7 # 7 days
+      duration: 60*60*24*30 # 30 days
     meta:
       name: '__b_skr_nltcs_mt'
   full:

--- a/spec/settings_spec.coffee
+++ b/spec/settings_spec.coffee
@@ -155,7 +155,7 @@ describe 'Settings', ->
         expect(@settings)
           .to.have.deep.property('cookies.basic.session.duration')
           .that.is.an('number')
-          .that.equals(60*60*24*7)
+          .that.equals(60*60*24*30)
 
       it 'has proper .meta.name', ->
         expect(@settings)


### PR DESCRIPTION
Turns out a cookie lifetime duration of just 7 days was unnecessarily too short.
Changing it to 30 days, same as with the _Full_ cookie policy.