### PR TITLE
Add purchased verification mark for parter sku reviews

### DIFF
--- a/spec/plugins/partner_sku_reviews_spec.coffee
+++ b/spec/plugins/partner_sku_reviews_spec.coffee
@@ -64,6 +64,7 @@ describe 'PartnerSkuReviews', ->
           "review": "Κάτοχος του κινητού γύρω στον 1 μήνα , ",
           "merged_review_notice_html": '<div class="merged-review-info">Η αξιολόγηση αφορά <span>μνήμη:</span> 64 GB, <span>ram:</span> 4 GB</div>',
           "rating": 5,
+          "purchased": true,
           "created_at": "01/07/2018",
           "votes_count": 110,
           "helpful_votes_count": 108,
@@ -89,6 +90,7 @@ describe 'PartnerSkuReviews', ->
           "review": "Μετά από άλλες 20 ημέρες χρήσης να προσθέσω και τα παρακάτω:",
           "merged_review_notice_html": '',
           "rating": 5,
+          "purchased": false,
           "created_at": "21/05/2018",
           "votes_count": 202,
           "helpful_votes_count": 196,
@@ -108,6 +110,7 @@ describe 'PartnerSkuReviews', ->
           "review": "Καποιος μας κανει πλακα...α δεν ειναι ενας ειναι πολλοι.    Αν το φοβαστε σαν εταιρια δωστε 400-600 ευρω σε αλλη μαρκα να νοιωσετε \"σιγουρια\".  Το παιρνεις 160-170 ευρω ,βαζεις και το MUIU 10 που βγηκε και επισημα και εχεις ενα Αι-Phone των 500++ ευρω. Το συστηνεις ανετα,δεν εχει περιττα προγραμαμτα μεσα με το ετσι θελω ,δεν κολλαει ,4g γρηγορο wifi διπλες αποστασεις ,δεν το λυπασαι,δεν μασαει, τρεχει ,τρεχει, αναβαθμηζεται,ομορφο,ωραια ξεκουραστη και αταραχη οθονη,καμερα ανωτερη απο πολλα σε βραδυ .\r\nΤο μεγαλο μειονεκτημα του ειναι η τιμη , που οταν την αναφερεις θα κλαις τα χρηματα που εδωσες σε παλιοτερα κινητα.",
           "merged_review_notice_html": '',
           "rating": 5,
+          "purchased": false,
           "created_at": "08/08/2018",
           "votes_count": 91,
           "helpful_votes_count": 88,
@@ -127,6 +130,7 @@ describe 'PartnerSkuReviews', ->
           "review": "Πριν ξεκινήσω να καταγράψω",
           "merged_review_notice_html": '',
           "rating": 5,
+          "purchased": false,
           "created_at": "11/08/2018",
           "votes_count": 76,
           "helpful_votes_count": 74,
@@ -146,6 +150,7 @@ describe 'PartnerSkuReviews', ->
           "review": "Μετά από χρήση μίας εβδομάδας (4gb/64gb)",
           "merged_review_notice_html": '',
           "rating": 5,
+          "purchased": false,
           "created_at": "29/05/2018",
           "votes_count": 55,
           "helpful_votes_count": 53,
@@ -534,6 +539,20 @@ describe 'PartnerSkuReviews', ->
 
           it 'displays rating stars', ->
             expect(@subject.querySelector('.sa-star-rating').innerHTML.trim()).to.not.be.empty
+
+          context 'when review is associated with a purchased product', ->
+            beforeEach ->
+              @subject = parent_doc.querySelectorAll('#\\@\\@flavor-product-reviews-extended .sa-reviews-list .sa-review')[0]
+
+            it 'displays the verification mark', ->
+              expect(@subject.querySelector('.sa-verification-mark').innerHTML.trim()).to.not.be.empty
+
+          context 'when review is not associated with a purchased product', ->
+            beforeEach ->
+              @subject = parent_doc.querySelectorAll('#\\@\\@flavor-product-reviews-extended .sa-reviews-list .sa-review')[1]
+
+            it 'does not display the verification mark', ->
+              expect(@subject.querySelector('.sa-verification-mark')).to.not.exist
 
           context 'when review belongs to another variation product', ->
             beforeEach ->

--- a/src/plugins/partner_sku_reviews.coffee
+++ b/src/plugins/partner_sku_reviews.coffee
@@ -223,6 +223,16 @@ class ExtendedSkuReviews extends BaseComponent
       </div>
     """
 
+  # verification mark
+  verificationMark = (purchased) ->
+    return '' unless purchased
+    
+    """
+      <div class="sa-verification-mark">
+        @@translations.partner_sku_reviews.verified_purchase
+      </div>
+    """
+
   userReviews = (reviews) ->
     review_elements = reviews.map (review, index) ->
       user = review.user
@@ -237,16 +247,19 @@ class ExtendedSkuReviews extends BaseComponent
             <img class="sa-review-avatar" src="#{user.avatar}" alt="avatar of user #{user.username}"/>
             <div class="sa-review-info-wrap">
               <div class="sa-review-info">
-                #{stars(review.rating)}
-                #{helpfulVoting(review.helpful_votes_count, review.votes_count)}
+                <div class="sa-review-voting-info">
+                  #{stars(review.rating)}
+                  #{helpfulVoting(review.helpful_votes_count, review.votes_count)}
+                </div>
+                <div class="sa-authorship-info">
+                  <span class="sa-review-author">#{user.username}</span>
+                  <span class="sa-review-date-wrap">
+                    <span class="sa-review-at">@@translations.partner_sku_reviews.at</span>
+                    <span class="sa-review-date">#{review.created_at}</span>
+                  </span>
+                </div>
               </div>
-              <div class="sa-authorship-info">
-                <span class="sa-review-author">#{user.username}</span>
-                <span class="sa-review-date-wrap">
-                  <span class="sa-review-at">@@translations.partner_sku_reviews.at</span>
-                  <span class="sa-review-date">#{review.created_at}</span>
-                </span>
-              </div>
+              #{verificationMark(review.purchased)}
             </div>
           </div>
           <div class="sa-review-main">
@@ -1135,19 +1148,44 @@ class PartnerSkuReviews
     }
 
     ##{flavor}-product-reviews-extended .sa-review-info-wrap {
+      display: flex;
+      flex-wrap: wrap;
       flex: 1 1 auto;
       -ms-flex: 1 1 auto;
+      /* We use a negative margin-top as an alternative to row-gap. A feature of flex box that has not been implemented yet. */
+      margin-top: -5px;
     }
 
-    ##{flavor}-product-reviews-extended .sa-review-info {
+    ##{flavor}-product-reviews-extended .sa-review-info-wrap > * {
+      margin-top: 5px;
+    }
+
+    ##{flavor}-product-reviews-extended .sa-review-voting-info {
       display: block;
       margin: 2px 0;
     }
 
-    ##{flavor}-product-reviews-extended .sa-review-info > *,
+    ##{flavor}-product-reviews-extended .sa-verification-mark {
+      font-size: 11px;
+      line-height: 20px;
+      color: #707070;
+    }
+
+    ##{flavor}-product-reviews-extended .sa-verification-mark:before {
+      content: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTQiIGhlaWdodD0iMTQiIHZpZXdCb3g9IjAgMCA4MCA4MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSIjNWNiODVjIj48cGF0aCBkPSJNMjUuNiAzMy44bC01LjUgNS44IDE1LjQgMTQuNSA0MS4xLTM5LjItNS41LTUuOC0zNS42IDM0eiIvPjxwYXRoIGQ9Ik02NC44IDM1Yy40IDEuOC42IDMuNi42IDUuNSAwIDE0LjctMTEuOSAyNi42LTI2LjYgMjYuNlMxMi4xIDU1LjIgMTIuMSA0MC41IDI0IDEzLjkgMzguNyAxMy45YzUuMyAwIDEwLjMgMS42IDE0LjUgNC4zbDUuNi01LjljLTUuNy00LTEyLjYtNi40LTIwLjEtNi40LTE5LjEgMC0zNC42IDE1LjUtMzQuNiAzNC42czE1LjUgMzQuNiAzNC42IDM0LjYgMzQuNi0xNS41IDM0LjYtMzQuNmMwLTQuMy0uOC04LjQtMi4yLTEyLjJMNjQuOCAzNXoiLz48L2c+PC9zdmc+");
+      vertical-align: text-top;
+    }
+
+    ##{flavor}-product-reviews-extended .sa-review-voting-info > *,
     ##{flavor}-product-reviews-extended .sa-authorship-info > * {
       display: inline;
       vertical-align: middle;
+    }
+
+    ##{flavor}-product-reviews-extended .sa-review-info {
+      flex: 1 1 auto;
+      -ms-flex: 1 1 auto;
+      margin-right: 100px;
     }
 
     ##{flavor}-product-reviews-extended .sa-review .sa-star-rating-wrapper {

--- a/translations/alve.yml
+++ b/translations/alve.yml
@@ -26,3 +26,4 @@ translations:
     write_review_for: 'Write a review for'
     and_help: 'and help other users!'
     review_this: 'Review this product'
+    verified_purchase: 'Verified purchase'

--- a/translations/scrooge.yml
+++ b/translations/scrooge.yml
@@ -27,3 +27,4 @@ translations:
     write_review_for: 'Write a review for'
     and_help: 'and help other users!'
     review_this: 'Review this product'
+    verified_purchase: 'Verified purchase'

--- a/translations/skroutz.yml
+++ b/translations/skroutz.yml
@@ -28,3 +28,4 @@ translations:
     write_review_for: 'Γράψε μια αξιολόγηση για το'
     and_help: 'και βοήθησε σημαντικά τους άλλους χρήστες!'
     review_this: 'Αξιολόγησε το προϊόν'
+    verified_purchase: 'Επιβεβαιωμένη αγορά'


### PR DESCRIPTION
We want to display if a review came from a verified purchase. The following screenshot is displayed on our partners' reviews page.

![image](https://user-images.githubusercontent.com/26133545/81670690-a8e38900-9450-11ea-9351-0dff051f378e.png)
